### PR TITLE
Feature: improve ALL TABS section

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -165,4 +165,5 @@ li a:hover {
 }
 .tab-item .icon:hover {
     cursor: pointer;
+    content: url(../images/trash-alt-solid-red.svg)
 }


### PR DESCRIPTION
# Story Title

[Task: deleting tabs one by one](https://github.com/Rashmi-Wijesekara/Tabsaver-chrome-extension/issues/7)
[Feature: improve ALL TABS section](https://github.com/Rashmi-Wijesekara/Tabsaver-chrome-extension/issues/4)


## Changes made

<!-- use jargons here -->

- generated separate event listeners for each tab deleting icon
- removed the selected tab from myLeads array & updated it in the local storage
- created an array which was contained the id elements of all the delete icons
- updated that array in both rendering functions
- called the tab deleting event listeners again inside that rendering functions

## How does the solution address the problem

<!-- explain for normal people -->

This PR will give the ability to delete each tab one by one instead of deleting all the tabs at once

## Linked issues

Resolves #7 
Resolves #4 

